### PR TITLE
Add changelog and gitignore setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.expo/
+.expo-shared/
+dist/
+build/
+.DS_Store
+*.log
+.env*
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Journal des modifications
+
+Tous les changements notables de ce projet seront documentés dans ce fichier.
+Ce journal se conforme aux principes de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/) et ce projet adhère au versionnage sémantique.
+
+## [Non publié]
+### Ajouté
+- Préparation d'une configuration de base pour l'application Expo (fichiers ignorés, documentation).
+
+### Modifié
+- Clarification des attentes concernant la rédaction de messages de commit compréhensibles.
+- Mise à jour de la documentation avec des références vers les ressources internes.
+
+## [0.1.0] - 2025-09-19 (initial)
+### Ajouté
+- Structure initiale du dépôt RUN'Accès avec la description fonctionnelle du projet.
+- Documentation de la vision produit et des fonctionnalités principales.

--- a/README.md
+++ b/README.md
@@ -249,9 +249,20 @@ Composants réutilisables (access‑first) :
 ---
 
 ## 🤝 Contribution
-1. Fork du repo → branche `feature/<nom>`  
-2. PR avec description claire (avant/après, captures)  
+1. Fork du repo → branche `feature/<nom>`
+2. PR avec description claire (avant/après, captures)
 3. Respect des règles d’accessibilité et du design system
+
+---
+
+## Références
+- [CHANGELOG](CHANGELOG.md)
+- Pensez à rédiger des messages de commit clairs et descriptifs pour faciliter le suivi du projet.
+
+---
+
+## Documents
+- [Bonjour RUN'Accès](docs/bonjour.md)
 
 ---
 

--- a/docs/bonjour.md
+++ b/docs/bonjour.md
@@ -1,0 +1,5 @@
+# Bonjour RUN'Accès
+
+Ceci est un test Codex pour valider la génération de documentation.
+Il confirme que le flux de travail de RUN'Accès peut être vérifié facilement.
+Ce document temporaire illustre les capacités de suivi de Codex.


### PR DESCRIPTION
## Summary
- add a React Native/Expo-friendly .gitignore to ignore common build and environment artifacts
- introduce a French Keep a Changelog file to track releases and upcoming work
- document references in the README, linking to the changelog and reminding contributors about clear commit messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1ea12c2c83269e0ed2cdd8bfa405