### PR TITLE
Add basic CI (Node lint & tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install
+        run: npm ci || npm install
+      - name: Lint (if present)
+        run: npm run lint --if-present
+      - name: Test (if present)
+        run: npm test --if-present
+      - name: Build (if present)
+        run: npm run build --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,28 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x]
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: npm
+
+      # N'exécute ces étapes que s'il existe au moins un package.json
       - name: Install
+        if: ${{ hashFiles('**/package.json') != '' }}
         run: npm ci || npm install
+
       - name: Lint (if present)
+        if: ${{ hashFiles('**/package.json') != '' }}
         run: npm run lint --if-present
+
       - name: Test (if present)
+        if: ${{ hashFiles('**/package.json') != '' }}
         run: npm test --if-present
+
       - name: Build (if present)
+        if: ${{ hashFiles('**/package.json') != '' }}
         run: npm run build --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: npm
 
       # N'exécute ces étapes que s'il existe au moins un package.json
-      - name: Install
+           - name: Install
         if: ${{ hashFiles('**/package.json') != '' }}
         run: npm ci || npm install
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs install, lint, test, and build (if present) across Node 18.x and 20.x on pushes to main and pull requests

## Testing
- not run (workflow only)

------
https://chatgpt.com/codex/tasks/task_e_68d3b0bfa8fc8326b3518b55a14bd95e